### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,14 +19,14 @@ repositories {
 
 dependencies {
     compileOnly "com.enonic.xp:script-api:${xpVersion}"
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.21.3'
+    implementation libs.jackson.databind
 
     testImplementation "com.enonic.xp:testing:${xpVersion}"
-    testImplementation(platform("org.junit:junit-bom:6.0.3"))
-    testImplementation(platform("org.mockito:mockito-bom:5.23.0"))
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(platform(libs.mockito.bom))
+    testImplementation libs.junit.jupiter
+    testRuntimeOnly libs.junit.platform.launcher
+    testImplementation libs.mockito.junit.jupiter
 }
 
 tasks.named('test', Test) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,12 @@
+[versions]
+jackson = "2.21.3"
+junit = "6.0.3"
+mockito = "5.23.0"
+
+[libraries]
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }


### PR DESCRIPTION
## Summary

Move the inline dependency versions in `build.gradle` into a new
`gradle/libs.versions.toml` catalog so this repo matches the dominant
pattern across the IdeaProjects tree. Pin-for-pin migration, no version
bumps.

Conventions adopted:

- Short, lowercase, hyphen-separated version keys (e.g. `jackson`,
  `junit`, `mockito`).
- `[versions]` and `[libraries]` sorted alphabetically.
- BOMs and their member artifacts share one version reference
  (`junit-bom`/`junit-jupiter`/`junit-platform-launcher` → `junit`;
  `mockito-bom`/`mockito-junit-jupiter` → `mockito`).
- `xpVersion` stays in `gradle.properties` — `com.enonic.xp:*` lines and
  `xplibs.*` accessors continue to use it inline.

## Catalog

```toml
[versions]
jackson = "2.21.3"
junit = "6.0.3"
mockito = "5.23.0"

[libraries]
jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }
```

## Verification

- `./gradlew build --refresh-dependencies` green.
- `./gradlew dependencies --configuration runtimeClasspath` and
  `--configuration testRuntimeClasspath` produce trees byte-identical to
  pre-migration HEAD.

## Test plan

- [ ] CI green on the PR branch
- [ ] No unintended version drift in resolved deps (compared against
      master)