### PR TITLE
Add @enonic-types/lib-license types package #150

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
 
   release:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -36,3 +36,15 @@ jacocoTestReport {
 
 check.dependsOn jacocoTestReport
 
+// Assemble the @enonic-types/lib-license npm package (published on release by the CI npmPublish step).
+tasks.register('assembleTypes', Copy) {
+    from 'types'
+    into layout.buildDirectory.dir('types')
+    filesMatching('package.json') {
+        filter { line ->
+            line.replaceAll(/"version":\s*"[^"]*"/, "\"version\": \"${project.version}\"")
+        }
+    }
+}
+jar.dependsOn assembleTypes
+

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,167 @@
+declare module "/lib/license" {
+    export interface KeyPair {
+        /**
+         * Base64-encoded string of the private key.
+         */
+        privateKey: string;
+
+        /**
+         * Base64-encoded string of the public key.
+         */
+        publicKey: string;
+
+        /**
+         * Serialized string form of the key pair, suitable for passing to `loadKeyPair`.
+         */
+        toString(): string;
+    }
+
+    export interface SerializedKeyPair {
+        privateKey: string;
+        publicKey: string;
+        string: string;
+    }
+
+    export interface LicenseParams {
+        /**
+         * The entity that issued this license.
+         */
+        issuedBy: string;
+
+        /**
+         * The entity this license is issued to.
+         */
+        issuedTo: string;
+
+        /**
+         * Time when the license was issued. ISO-8601 string or Date.
+         */
+        issueTime?: string | Date;
+
+        /**
+         * Expiration time for the license. ISO-8601 string or Date.
+         */
+        expiryTime?: string | Date;
+
+        /**
+         * Custom key-value properties. Values are coerced to strings.
+         */
+        properties?: Record<string, unknown>;
+    }
+
+    export interface ValidateLicenseParams {
+        /**
+         * Encoded license string. If omitted, the library looks in `XP_HOME/license/<appKey>.lic`,
+         * falling back to a license installed in the repository via `installLicense`.
+         */
+        license?: string | null;
+
+        /**
+         * Public key used to validate the license. If omitted, the library reads
+         * `src/main/resources/app.pub` from the current app.
+         */
+        publicKey?: string | null;
+
+        /**
+         * Application key. If omitted, the current application key is used.
+         */
+        appKey?: string | null;
+    }
+
+    export interface InstallLicenseParams {
+        /**
+         * Encoded license string.
+         */
+        license: string;
+
+        /**
+         * Public key used to validate the license. If omitted, the library reads
+         * `src/main/resources/app.pub` from the current app.
+         */
+        publicKey?: string | null;
+
+        /**
+         * Application key.
+         */
+        appKey: string;
+    }
+
+    export interface LicenseDetails {
+        /**
+         * The entity this license is issued to.
+         */
+        issuedTo: string;
+
+        /**
+         * The entity that issued this license.
+         */
+        issuedBy: string;
+
+        /**
+         * ISO-8601 string of the issue time, if set.
+         */
+        issueTime?: string;
+
+        /**
+         * ISO-8601 string of the expiry time, if set.
+         */
+        expiryTime?: string;
+
+        /**
+         * Whether the license has expired.
+         */
+        expired: boolean;
+
+        /**
+         * Custom key-value properties supplied when the license was generated.
+         */
+        data: Record<string, string>;
+    }
+
+    /**
+     * Generates a public/private key pair to be used for license generation and validation.
+     */
+    export function generateKeyPair(): KeyPair;
+
+    /**
+     * Loads a key pair from its serialized string form.
+     *
+     * @param keyPairString Serialized key pair.
+     * @returns The key pair, or `null` if the input is not valid.
+     */
+    export function loadKeyPair(keyPairString: string): SerializedKeyPair | null;
+
+    /**
+     * Generates a license based on a private key and license details.
+     *
+     * @param privateKey Private key string.
+     * @param license License details.
+     * @returns The encoded license string.
+     */
+    export function generateLicense(privateKey: string, license: LicenseParams): string;
+
+    /**
+     * Validates a license using the public key and returns the license details.
+     *
+     * @param params Validation parameters. All fields are optional; see `ValidateLicenseParams`.
+     * @returns The license details, or `null` if the license is not valid.
+     */
+    export function validateLicense(params?: ValidateLicenseParams): LicenseDetails | null;
+
+    /**
+     * Validates and stores a license in the XP node repository.
+     *
+     * @param params Installation parameters.
+     * @returns `true` if the license was successfully installed, `false` otherwise.
+     */
+    export function installLicense(params: InstallLicenseParams): boolean;
+
+    /**
+     * Removes an installed license from the XP repository.
+     *
+     * @param appKey Application key.
+     */
+    export function uninstallLicense(appKey: string): void;
+}
+
+export {};

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@enonic-types/lib-license",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP License library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-license",
+    "license",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-license#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-license.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-license/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
## Summary

Publish a TypeScript types package **`@enonic-types/lib-license`** so consumers no longer maintain local `.d.ts` files for `/lib/license`.

Modelled on enonic/lib-mustache PR #66; verified against `src/main/resources/lib/license.js` and the underlying Java beans.

## Changes

- **`types/index.d.ts`** — ambient `declare module "/lib/license"` for every export:
  - `generateKeyPair()` → `KeyPair` (with `.privateKey`, `.publicKey`, `.toString()`)
  - `loadKeyPair(keyPairString)` → `SerializedKeyPair | null` (raw `__.toNativeObject` shape)
  - `generateLicense(privateKey, license)` → `string`
  - `validateLicense(params?)` → `LicenseDetails | null` (matches `LicenseMapper` output shape: `issuedTo`, `issuedBy`, optional `issueTime`/`expiryTime` ISO strings, `expired`, `data`)
  - `installLicense(params)` → `boolean`
  - `uninstallLicense(appKey)` → `void`
- **`types/package.json`** — `@enonic-types/lib-license`, Apache-2.0, `publishConfig.access: public`, `version: "0.0.0"` (substituted from `project.version` at build).
- **`build.gradle`** — `assembleTypes` Copy task → `build/types` (version substituted); `jar.dependsOn assembleTypes`.
- **`.github/workflows/enonic-gradle.yml`** — `npmPublish: true` on `build-and-publish` + top-level `permissions: id-token: write` + `contents: write` for OIDC trusted publishing.

## Verification

- `./gradlew build` green locally.
- `build/types/` contains `index.d.ts` + `package.json` with `"version": "4.1.0-SNAPSHOT"` substituted.
- `types/index.d.ts` type-checks under `strict: true` against a small sample consumer.

## Notes

- Depends on enonic/release-tools#71 (merged) — provides the `npmPublish` input to `build-and-publish`.
- First publish of the brand-new `@enonic-types/lib-license` may need npm trusted-publisher setup for this repo.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)