### PR TITLE
Align docs to lib-cors layout #152

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - "4.x"
+      - "3.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,5 +1,7 @@
 = Application Licensing
 
+NOTE: Versions 4.x target XP 8+.
+
 [[licensemanager]]
 == License Manager
 

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,6 +1,6 @@
 {
   "versions": [
     { "label": "stable", "checkout": "4.x", "latest": true },
-    { "label": "next", "checkout": "master" }
+    { "label": "3.x", "checkout": "3.x" }
   ]
 }


### PR DESCRIPTION
## Summary

Aligns `lib-license` docs to the reference `enonic/lib-cors` layout, on `master`.

- `docs/index.adoc`: adds `NOTE: Versions 4.x target XP 8+.` near the top (mirrors lib-cors `master` / `2.x`).
- `docs/versions.json`: switches to `stable` -> `4.x` (latest) and `3.x` -> `3.x`; drops the `next` -> `master` entry.
- `.github/workflows/enonic-docgen.yml`: adds `3.x` to `on.push.branches` so every branch listed in `versions.json` re-triggers docs.

## Version-history clutter cleanup

Read `docs/**` end-to-end looking for `(added in vX.Y)` / `(since X.Y)` annotations, `Starting from version X …` / `Introduced in X` notes, and pre-XP8 legacy carve-outs. **Found none** — the current `index.adoc` is already clean (no changelog-style prose, no legacy-version caveats). Nothing to strip beyond the structural changes above.

## Follow-up

Once this lands on `master`, the doc-only bits (the `NOTE:` in `index.adoc` and the `3.x` addition to the docgen workflow) will be cherry-picked to the `4.x` stable branch as a separate PR. The `3.x` branch is intentionally left alone.

Closes #152