### PR TITLE
Align docs to lib-cors layout #152

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - "4.x"
+      - "3.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,5 +1,7 @@
 = Application Licensing
 
+NOTE: Versions 4.x target XP 8+.
+
 [[licensemanager]]
 == License Manager
 

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,6 @@
+{
+  "versions": [
+    { "label": "stable", "checkout": "4.x", "latest": true },
+    { "label": "3.x", "checkout": "3.x" }
+  ]
+}


### PR DESCRIPTION
## Summary

Cherry-picks the doc-alignment changes from #153 (against `master`) to the `4.x` stable branch.

- `docs/index.adoc`: adds `NOTE: Versions 4.x target XP 8+.` near the top.
- `docs/versions.json`: introduces the file on this branch, mirroring `master`, with `stable` -> `4.x` (latest) and `3.x` -> `3.x`.
- `.github/workflows/enonic-docgen.yml`: adds `3.x` to `on.push.branches` so this branch's own docgen setup covers every branch in `versions.json`.

## Version-history clutter cleanup

Same review as for #153: `docs/**` on `4.x` was checked for `(added in vX.Y)` / `(since X.Y)` annotations and pre-XP8 changelog notes — none found, nothing to strip.

## Untouched

The `3.x` branch is intentionally left as-is; a target-XP `NOTE:` was already added there in b7cd742 and its docgen workflow trigger was added in 93664f1.

Should merge after #153 lands so `master` and `4.x` stay in sync on doc structure.

Closes #152